### PR TITLE
Use hash_hmac() rather than crypt() to generate hash.

### DIFF
--- a/bp_lib.php
+++ b/bp_lib.php
@@ -79,7 +79,7 @@ function bpCreateInvoice($orderId, $price, $posData, $options = array()) {
 	
 	$pos = array('posData' => $posData);
 	if ($bpOptions['verifyPos'])
-		$pos['hash'] = crypt(serialize($posData), $options['apiKey']);
+		$pos['hash'] = bpHash(serialize($posData), $options['apiKey']);
 	$options['posData'] = json_encode($pos);
 	
 	$options['orderID'] = $orderId;
@@ -117,7 +117,7 @@ function bpVerifyNotification($apiKey = false) {
 		return 'no posData';
 		
 	$posData = json_decode($json['posData'], true);
-	if($bpOptions['verifyPos'] and $posData['hash'] != crypt(serialize($posData['posData']), $apiKey)) 
+	if($bpOptions['verifyPos'] and $posData['hash'] != bpHash(serialize($posData['posData']), $apiKey))
 		return 'authentication failed (bad hash)';
 	$json['posData'] = $posData['posData'];
 		
@@ -139,3 +139,8 @@ function bpGetInvoice($invoiceId, $apiKey=false) {
 	return $response;	
 }
 
+// Generates a keyed hash.
+function bpHash($data, $key) {
+	$hmac = base64_encode(hash_hmac('sha256', $data, $key, TRUE));
+	return strtr($hmac, array('+' => '-', '/' => '_', '=' => ''));
+}


### PR DESCRIPTION
PHP crypt() function uses only the first two characters of the salt and the first eight characters of the data - the latter of which may be predictable as it is a serialized PHP object, array, etc. The verification function could be vastly improved by using instead the hash_hmac() function (available in PHP 5.1.2 and later) which uses all of the data and all of the key to generate the hash.
