### PR TITLE
Override bp_options.php more consistently

### DIFF
--- a/bp_lib.php
+++ b/bp_lib.php
@@ -130,7 +130,7 @@ function bpVerifyNotification($apiKey = false, $options = array()) {
 }
 
 // $options can include ('apiKey')
-function bpGetInvoice($invoiceId, $apiKey=false, $options = array()) {
+function bpGetInvoice($invoiceId, $apiKey=false) {
 	global $bpOptions;
 	if (!$apiKey)
 		$apiKey = $bpOptions['apiKey'];		


### PR DESCRIPTION
In cases where this is used without putting any settings in bp_options.php, the library allows overriding any of the options in bpCreateInvoice() except for the verify hash, which still reads from just the pre-merged options array.

Even though you can override options in bpCreateInvoice, you can't override anything in the verification function, so I added the same array merge that was in the invoice creation to the verification, then modified the variables to used the overridden, merged array.
