### PR TITLE
Updated key_storage option to take class name

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -42,10 +42,11 @@ Used mostly for testing. You shouldn't need to change or update this.
 key_storage
 -----------
 
-The keys that this library generates can be stored on the filesystem and custom
-storage options can be created such as saving the keys to a database or even
-S3. This is still experimental and the only options that are supported are
-``mock`` and ``encypted_filesystem`` with filesystem being the default.
+The ``key_storage`` option allows you to give a class for persisting keys and
+loading them. The class must also implement ``Bitpay\Storage\StorageInterface``.
+
+By default this uses the ``Bitpay\Storage\EncryptedFilesystemStorage``.
+
 
 key_storage_password
 --------------------

--- a/src/Bitpay/DependencyInjection/BitpayExtension.php
+++ b/src/Bitpay/DependencyInjection/BitpayExtension.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 
@@ -14,7 +14,6 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 /**
- *
  * @package Bitpay
  */
 class BitpayExtension implements ExtensionInterface
@@ -36,10 +35,7 @@ class BitpayExtension implements ExtensionInterface
             'adapter.class',
             'Bitpay\Client\Adapter\\'.ContainerBuilder::camelize($config['adapter']).'Adapter'
         );
-        $container->setParameter(
-            'key_storage.class',
-            'Bitpay\Storage\\'.ContainerBuilder::camelize($config['key_storage']).'Storage'
-        );
+        $container->setParameter('key_storage.class', $config['key_storage']);
     }
 
     /**

--- a/tests/Bitpay/Config/ConfigurationTest.php
+++ b/tests/Bitpay/Config/ConfigurationTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
+ * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
+ */
+
+namespace Bitpay\Config;
+
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcessAndValidate()
+    {
+        $processor       = new Processor();
+        $processedConfig = $processor->processConfiguration(
+            new Configuration(),
+            array()
+        );
+
+        $this->assertArrayHasKey('public_key', $processedConfig);
+        $this->assertArrayHasKey('private_key', $processedConfig);
+        $this->assertArrayHasKey('sin_key', $processedConfig);
+        $this->assertArrayHasKey('network', $processedConfig);
+        $this->assertArrayHasKey('adapter', $processedConfig);
+        $this->assertArrayHasKey('key_storage', $processedConfig);
+        $this->assertArrayHasKey('key_storage_password', $processedConfig);
+        $this->assertCount(7, $processedConfig);
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testInvalidKeyStorageClass()
+    {
+        $processor       = new Processor();
+        $processedConfig = $processor->processConfiguration(
+            new Configuration(),
+            array(
+                'bitpay' => array(
+                    'key_storage' => 'Foo\Bar'
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
Increased test coverage, modified to use class names instead of enums.

This change is needed for at least the Magento Plugin since the plugin uses a custom class to persist and load keys using Magento classes. This should also help other plugins as well.
