### PR TITLE
Token Update

### DIFF
--- a/src/Bitpay/Token.php
+++ b/src/Bitpay/Token.php
@@ -37,6 +37,16 @@ class Token implements TokenInterface
     protected $policies;
 
     /**
+     * @var string
+     */
+    protected $pairingCode;
+
+    /**
+     * @var \DateTime
+     */
+    protected $pairingExpiration;
+
+    /**
      */
     public function __construct()
     {
@@ -104,7 +114,7 @@ class Token implements TokenInterface
         return $this->createdAt;
     }
 
-    public function setCreatedAt($createdAt)
+    public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
 
@@ -122,6 +132,36 @@ class Token implements TokenInterface
     public function setPolicies($policies)
     {
         $this->policies = $policies;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPairingCode()
+    {
+        return $this->pairingCode;
+    }
+    
+    public function setPairingCode($pairingCode)
+    {
+        $this->pairingCode = $pairingCode;
+        
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getPairingExpiration()
+    {
+        return $this->pairingExpiration;
+    }
+
+    public function setPairingExpiration(\DateTime $pairingExpiration)
+    {
+        $this->pairingExpiration = $pairingExpiration;
 
         return $this;
     }

--- a/src/Bitpay/TokenInterface.php
+++ b/src/Bitpay/TokenInterface.php
@@ -35,4 +35,14 @@ interface TokenInterface
      * @return array
      */
     public function getPolicies();
+    
+    /**
+     * @return string
+     */
+    public function getPairingCode();
+
+    /**
+     * @return \DateTime
+     */
+    public function getPairingExpiration();
 }

--- a/tests/Bitpay/Client/ClientTest.php
+++ b/tests/Bitpay/Client/ClientTest.php
@@ -361,6 +361,12 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->client->createToken();
         $this->assertInstanceOf('Bitpay\TokenInterface', $token);
+
+        $response = $this->getMockResponse();
+        $response->method('getBody')->willReturn(file_get_contents(__DIR__ . '/../../DataFixtures/tokens_pairing.json'));
+
+        $token = $this->client->createToken();
+        $this->assertInstanceOf('Bitpay\TokenInterface', $token);
     }
 
     /**

--- a/tests/Bitpay/TokenTest.php
+++ b/tests/Bitpay/TokenTest.php
@@ -80,8 +80,9 @@ class TokenTest extends \PHPUnit_Framework_TestCase
     public function testSetCreatedAt()
     {
         $token = new Token();
-        $token->setCreatedAt('createdAt');
-        $this->assertSame('createdAt', $token->getCreatedAt());
+        $now = new \DateTime();
+        $token->setCreatedAt($now);
+        $this->assertSame($now, $token->getCreatedAt());
     }
 
     public function testGetPolicies()
@@ -98,5 +99,38 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $token = new Token();
         $token->setPolicies('policy');
         $this->assertSame('policy', $token->getPolicies());
+    }
+
+    public function testGetPairingCode()
+    {
+        $token = new Token();
+        $this->assertNull($token->getPairingCode());
+    }
+
+    /**
+     * @depends testGetPairingCode
+     */
+    public function testSetPairingCode()
+    {
+        $token = new Token();
+        $token->setPairingCode('abcd456');
+        $this->assertSame('abcd456', $token->getPairingCode());
+    }
+
+    public function testGetPairingExpiration()
+    {
+        $token = new Token();
+        $this->assertNull($token->getPairingExpiration());
+    }
+
+    /**
+     * @depends testGetPairingExpiration
+     */
+    public function testSetPairingExpiration()
+    {
+        $token = new Token();
+        $now = new \DateTime();
+        $token->setPairingExpiration($now);
+        $this->assertSame($now, $token->getPairingExpiration());
     }
 }

--- a/tests/DataFixtures/tokens_pairing.json
+++ b/tests/DataFixtures/tokens_pairing.json
@@ -1,0 +1,12 @@
+{
+    "data": [
+        {
+            "policies": [],
+            "token": "testToken",
+            "facade": "pos",
+            "dateCreated": "123456789",
+            "pairingExpiration": "133456789",
+            "pairingCode": "abcd456"
+        }
+    ]
+}


### PR DESCRIPTION
Updated \Bitpay\Token to include pairingCode and pairingExpiration properties
Fixed \Bitpay\Client\Client to set tokens correctly:
    \Bitpay\Token::createdAt is correctly set as a DateTime object

Tests written for all changes