### PR TITLE
Namespaced class name references/ Custom HTTP Accept Version Header

### DIFF
--- a/src/Bitpay/Client/Client.php
+++ b/src/Bitpay/Client/Client.php
@@ -719,7 +719,7 @@ class Client implements ClientInterface
 
         $request->setHeader('X-BitPay-Plugin-Info', sprintf('%s/%s', self::NAME, self::VERSION));
         $request->setHeader('Content-Type', 'application/json');
-        $request->setHeader('X-Accept-Version', '2.2.6');
+        $request->setHeader('X-Accept-Version', '2.0.0');
     }
 
     /**

--- a/src/Bitpay/Client/Client.php
+++ b/src/Bitpay/Client/Client.php
@@ -15,6 +15,7 @@ use Bitpay\Util\Util;
 use Bitpay\PublicKey;
 use Bitpay\PrivateKey;
 
+date_default_timezone_set('utc');
 /**
  * Client used to send requests and receive responses for BitPay's Web API.
  *

--- a/src/Bitpay/Invoice.php
+++ b/src/Bitpay/Invoice.php
@@ -6,6 +6,8 @@
 
 namespace Bitpay;
 
+date_default_timezone_set('utc');
+
 /**
  * @package Bitpay
  */
@@ -433,6 +435,8 @@ class Invoice implements InvoiceInterface
     {
         if (is_float($btcPrice)) {
             $this->btcPrice = $btcPrice;
+        } else if (is_numeric($btcPrice)) {
+            $this->btcPrice = floatval($btcPrice);
         }
 
         return $this;
@@ -454,8 +458,11 @@ class Invoice implements InvoiceInterface
     {
         if (is_a($invoiceTime, 'DateTime')) {
             $this->invoiceTime = $invoiceTime;
+        } else if (is_numeric($invoiceTime)) {
+            $invoiceDateTime = new \DateTime();
+            $invoiceDateTime->setTimestamp($invoiceTime);
+            $this->invoiceTime = $invoiceDateTime;
         }
-
         return $this;
     }
 
@@ -475,8 +482,11 @@ class Invoice implements InvoiceInterface
     {
         if (is_a($expirationTime, 'DateTime')) {
             $this->expirationTime = $expirationTime;
+        } else if (is_numeric($expirationTime)) {
+            $expirationDateTime = new \DateTime();
+            $expirationDateTime->setTimestamp($expirationTime);
+            $this->expirationTime = $expirationDateTime;
         }
-
         return $this;
     }
 
@@ -496,6 +506,10 @@ class Invoice implements InvoiceInterface
     {
         if (is_a($currentTime, 'DateTime')) {
             $this->currentTime = $currentTime;
+        } else if (is_numeric($currentTime)) {
+            $currentDateTime = new \DateTime();
+            $currentDateTime->setTimestamp($currentTime);
+            $this->currentTime = $currentDateTime;
         }
 
         return $this;

--- a/src/Bitpay/Invoice.php
+++ b/src/Bitpay/Invoice.php
@@ -131,7 +131,7 @@ class Invoice implements InvoiceInterface
      */
     public function getPrice()
     {
-        if (is_a($this->item, 'Item')) {
+        if (is_a($this->item, '\Bitpay\Item')) {
             return $this->getItem()->getPrice();
         } else {
             return 0.000000;
@@ -169,7 +169,7 @@ class Invoice implements InvoiceInterface
      */
     public function setCurrency(CurrencyInterface $currency)
     {
-        if (is_a($currency, 'Currency')) {
+        if (is_a($currency, '\Bitpay\Currency')) {
             $this->currency = $currency;
         }
 
@@ -194,7 +194,7 @@ class Invoice implements InvoiceInterface
      */
     public function setItem(ItemInterface $item)
     {
-        if (is_a($item, 'Item')) {
+        if (is_a($item, '\Bitpay\Item')) {
             $this->item = $item;
         }
 
@@ -219,7 +219,7 @@ class Invoice implements InvoiceInterface
      */
     public function setBuyer(BuyerInterface $buyer)
     {
-        if (is_a($buyer, 'Buyer')) {
+        if (is_a($buyer, '\Bitpay\Buyer')) {
             $this->buyer = $buyer;
         }
 
@@ -700,7 +700,7 @@ class Invoice implements InvoiceInterface
      */
     public function setToken(TokenInterface $token)
     {
-        if (is_a($token, 'Token')) {
+        if (is_a($token, '\Bitpay\Token')) {
             $this->token = $token;
         }
 

--- a/src/Bitpay/Payout.php
+++ b/src/Bitpay/Payout.php
@@ -6,6 +6,8 @@
 
 namespace Bitpay;
 
+date_default_timezone_set('utc');
+
 /**
  * Class Payout
  * @package Bitpay

--- a/src/Bitpay/PayoutInstruction.php
+++ b/src/Bitpay/PayoutInstruction.php
@@ -6,6 +6,8 @@
 
 namespace Bitpay;
 
+date_default_timezone_set('utc');
+
 /**
  * Class PayoutInstruction
  * @package Bitpay

--- a/src/Bitpay/Token.php
+++ b/src/Bitpay/Token.php
@@ -6,6 +6,8 @@
 
 namespace Bitpay;
 
+date_default_timezone_set('utc');
+
 /**
  * @package Bitpay
  */
@@ -169,7 +171,7 @@ class Token implements TokenInterface
     public function setPairingCode($pairingCode)
     {
         $this->pairingCode = $pairingCode;
-        
+
         return $this;
     }
 

--- a/tests/Bitpay/Client/ClientTest.php
+++ b/tests/Bitpay/Client/ClientTest.php
@@ -163,9 +163,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('new', $invoice->getStatus());
         $this->assertEquals('0.0632', $invoice->getBtcPrice());
         $this->assertEquals(19.95, $invoice->getPrice());
-        $this->assertEquals(1412594514486, $invoice->getInvoiceTime());
-        $this->assertEquals(1412595414486, $invoice->getExpirationTime());
-        $this->assertEquals(1412594514518, $invoice->getCurrentTime());
+        $this->assertEquals(1412594514486, $invoice->getInvoiceTime()->getTimestamp());
+        $this->assertEquals(1412595414486, $invoice->getExpirationTime()->getTimestamp());
+        $this->assertEquals(1412594514518, $invoice->getCurrentTime()->getTimestamp());
         $this->assertEquals('0.0000', $invoice->getBtcPaid());
         $this->assertEquals(315.7, $invoice->getRate());
         $this->assertEquals(false, $invoice->getExceptionStatus());
@@ -272,7 +272,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $this->client->createInvoice($invoice);
     }
-    
+
     /**
      * @depends testCreateInvoice
      */

--- a/tests/Bitpay/InvoiceTest.php
+++ b/tests/Bitpay/InvoiceTest.php
@@ -18,7 +18,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetPrice()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getPrice());
+        $this->assertSame($this->invoice->getPrice(), 0.0);
     }
 
     /**
@@ -34,7 +34,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetCurrency()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getCurrency());
+        $this->assertInstanceOf('Bitpay\Currency', $this->invoice->getCurrency());
     }
 
     /**
@@ -101,7 +101,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetNotificationEmail()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getNotificationEmail());
+        $this->assertSame($this->invoice->getNotificationEmail(), '');
     }
 
     /**
@@ -117,7 +117,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetNotificationUrl()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getNotificationUrl());
+        $this->assertSame($this->invoice->getNotificationUrl(), '');
     }
 
     /**
@@ -133,7 +133,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetRedirectUrl()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getRedirectUrl());
+        $this->assertSame($this->invoice->getRedirectUrl(), '');
     }
 
     /**
@@ -149,7 +149,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetPosData()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getPosData());
+        $this->assertSame($this->invoice->getPosData(), '');
     }
 
     /**
@@ -165,7 +165,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetStatus()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getStatus());
+        $this->assertSame($this->invoice->getStatus(), '');
     }
 
     /**
@@ -187,7 +187,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetId()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getId());
+        $this->assertSame($this->invoice->getId(), '');
     }
 
     /**
@@ -203,7 +203,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetUrl()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getUrl());
+        $this->assertSame($this->invoice->getUrl(), '');
     }
 
     /**
@@ -219,7 +219,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetBtcPrice()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getBtcPrice());
+        $this->assertSame($this->invoice->getBtcPrice(), 0.0);
     }
 
     /**
@@ -294,7 +294,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetOrderId()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getOrderId());
+        $this->assertSame($this->invoice->getOrderId(), '');
     }
 
     /**
@@ -382,7 +382,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetExceptionStatus()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getExceptionStatus());
+        $this->assertSame($this->invoice->getExceptionStatus(), '');
     }
 
     /**
@@ -398,7 +398,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetBtcPaid()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getBtcPaid());
+        $this->assertSame($this->invoice->getBtcPaid(), 0.0);
     }
 
     /**
@@ -414,7 +414,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testGetRate()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertNull($this->invoice->getRate());
+        $this->assertSame($this->invoice->getRate(), 0.0);
     }
 
     /**


### PR DESCRIPTION
1. is_a function is now returning false unless the class name is given
with the namespace reference.
2. X-Accept-Version needs to be 2.0.0, referring to the API version and
not the plugin version.