### PR TITLE
fix timezone ids for case-sensitive systems

### DIFF
--- a/src/Bitpay/Client/Client.php
+++ b/src/Bitpay/Client/Client.php
@@ -15,7 +15,7 @@ use Bitpay\Util\Util;
 use Bitpay\PublicKey;
 use Bitpay\PrivateKey;
 
-date_default_timezone_set('utc');
+date_default_timezone_set('UTC');
 /**
  * Client used to send requests and receive responses for BitPay's Web API.
  *

--- a/src/Bitpay/Invoice.php
+++ b/src/Bitpay/Invoice.php
@@ -6,7 +6,7 @@
 
 namespace Bitpay;
 
-date_default_timezone_set('utc');
+date_default_timezone_set('UTC');
 
 /**
  * @package Bitpay

--- a/src/Bitpay/Payout.php
+++ b/src/Bitpay/Payout.php
@@ -6,7 +6,7 @@
 
 namespace Bitpay;
 
-date_default_timezone_set('utc');
+date_default_timezone_set('UTC');
 
 /**
  * Class Payout

--- a/src/Bitpay/PayoutInstruction.php
+++ b/src/Bitpay/PayoutInstruction.php
@@ -6,7 +6,7 @@
 
 namespace Bitpay;
 
-date_default_timezone_set('utc');
+date_default_timezone_set('UTC');
 
 /**
  * Class PayoutInstruction


### PR DESCRIPTION
on case-sensitive systems (like debian) the timezone UTC must be written in uppercase