### PR TITLE
Currency Additions

### DIFF
--- a/src/Bitpay/Currency.php
+++ b/src/Bitpay/Currency.php
@@ -36,7 +36,8 @@ class Currency implements CurrencyInterface
         'SCR', 'SDG', 'SEK', 'SGD', 'SHP', 'SLL', 'SOS', 'SRD', 'STD', 'SVC',
         'SYP', 'SZL', 'THB', 'TJS', 'TMT', 'TND', 'TOP', 'TRY', 'TTD', 'TWD',
         'TZS', 'UAH', 'UGX', 'USD', 'UYU', 'UZS', 'VEF', 'VND', 'VUV', 'WST',
-        'XAF', 'XAG', 'XAU', 'XCD', 'XOF', 'XPF', 'YER', 'ZAR', 'ZMW', 'ZWL'
+        'XAF', 'XAG', 'XAU', 'XCD', 'XOF', 'XPF', 'YER', 'ZAR', 'ZMW', 'ZWL',
+        'CUP', 'IRR', 'KPW'
     );
 
     /**


### PR DESCRIPTION
closes #187 
- Added Cuban Peso, Iran, and North Korean currencies. These are valid currencies, but we won't payout in these currencies. They are added for completeness of the api only. Meaning, we acknowledge these are valid currency symbols, but payouts are disabled.