### PR TITLE
Removed gmp dependency when testing BcEngine

### DIFF
--- a/tests/Bitpay/Math/BcEngineTest.php
+++ b/tests/Bitpay/Math/BcEngineTest.php
@@ -37,9 +37,11 @@ class BcEngineTest extends \PHPUnit_Framework_TestCase
         $b = '1234123412341234123412341234123412412341234213412421341342342';
         $c = '0x1234123412341234123412341234123412412341234213412421341342342';
         $math = new BcEngine();
-        $this->assertEquals(gmp_strval(gmp_add($a, $a)), $math->add($a, $a));
-        $this->assertEquals(gmp_strval(gmp_add($b, $b)), $math->add($b, $b));
-        $this->assertEquals(gmp_strval(gmp_add($c, $c)), $math->add($c, $c));
+        $this->assertEquals('2468', $math->add($a, $a));
+        $this->assertEquals('2468246824682468246824682468246824824682468426824842682684684',
+            $math->add($b, $b));
+        $this->assertEquals('4020328592351456034599241982311497811554079037632048678982517743814198916',
+            $math->add($c, $c));
         $this->assertEquals(2, $math->add(1, 1));
     }
 
@@ -49,9 +51,10 @@ class BcEngineTest extends \PHPUnit_Framework_TestCase
         $b = '1234123412341234123412341234123412412341234213412421341342342';
         $c = '0x1234123412341234123412341234123412412341234213412421341342342';
         $math = new BcEngine();
-        $this->assertEquals(gmp_strval(gmp_cmp($a, $a)), $math->cmp($a, $a));
-        $this->assertEquals(gmp_strval(gmp_cmp($b, $b)), $math->cmp($b, $b));
-        $this->assertEquals(gmp_strval(gmp_cmp($c, $c)), $math->cmp($c, $c));
+        $this->assertEquals('0', $math->cmp($a, $a));
+        $this->assertEquals('1', $math->cmp($b, $a));
+        $this->assertEquals('-1', $math->cmp($a, $b));
+        $this->assertEquals('0', $math->cmp($c, $c));
         $this->assertEquals(0, $math->cmp(1, 1));
     }
 
@@ -60,10 +63,14 @@ class BcEngineTest extends \PHPUnit_Framework_TestCase
         $a = 1234;
         $b = '1234123412341234123412341234123412412341234213412421341342342';
         $c = '0x1234123412341234123412341234123412412341234213412421341342342';
+        $d = 256;
         $math = new BcEngine();
-        $this->assertEquals(gmp_strval(gmp_div($a, $a)), $math->div($a, $a));
-        $this->assertEquals(gmp_strval(gmp_div($b, $b)), $math->div($b, $b));
-        $this->assertEquals(gmp_strval(gmp_div($c, $c)), $math->div($c, $c));
+        $this->assertEquals('4', $math->div($a, $d));
+        $this->assertEquals('4820794579457945794579457945794579735707946146142270864618', $math->div($b, $d));
+        $this->assertEquals('1', $math->div($c, $c));
+        $this->assertEquals('7852204281936437567576644496702144163191560620375095076137729968387107',
+            $math->div($c, $d));
+
         $this->assertEquals(1, $math->div(1, 1));
     }
 
@@ -76,12 +83,12 @@ class BcEngineTest extends \PHPUnit_Framework_TestCase
         $c = '0x1234123412341234123412341234123412412341234213412421341342342';
         
         
-        $this->assertEquals(gmp_strval(gmp_invert($a, $a)), $math->invertm($a, $a));
-        $this->assertEquals(gmp_strval(gmp_invert($b, $b)), $math->invertm($b, $b));
-        $this->assertEquals(gmp_strval(gmp_invert($c, $c)), $math->invertm($c, $c));
+        $this->assertEquals(0, $math->invertm($a, $a));
+        $this->assertEquals(0, $math->invertm($b, $b));
+        $this->assertEquals(0, $math->invertm($c, $c));
 
-        $this->assertEquals(gmp_strval(gmp_invert(15, 14)), $math->invertm(15, 14));
-    	$this->assertEquals(gmp_strval(gmp_invert(-1, 1)), $math->invertm(-1, 1));
+        $this->assertEquals('1', $math->invertm(15, 14));
+    	$this->assertEquals(0, $math->invertm(-1, 1));
         $this->assertEquals(0, $math->invertm(1, 1));
 
         $o = '2';
@@ -99,10 +106,10 @@ class BcEngineTest extends \PHPUnit_Framework_TestCase
         $b = '-1675975991242824637446753124775730765934920727574049172215445180465096172921808707643480960976619010162856846742450225672776411590632518780962349126898196';
         $c = '115792089237316195423570985008687907853269984665640564039457584007908834671663';
         $math = new BcEngine();
-        $gmp = new GmpEngine();
-        $this->assertEquals($gmp->mod($a, $a), $math->mod($a, $a));
-        $this->assertEquals($gmp->mod($a, $b), $math->mod($a, $b));
-        $this->assertEquals($gmp->mod($b, $c), $math->mod($b, $c));
+        $this->assertEquals(0, $math->mod($a, $a));
+        $this->assertEquals('1234', $math->mod($a, $b));
+        $this->assertEquals('14474011154664524427946373126085988481658748083205070504932198000988604333958'
+            , $math->mod($b, $c));
 
     }
 
@@ -112,9 +119,11 @@ class BcEngineTest extends \PHPUnit_Framework_TestCase
         $b = '1234123412341234123412341234123412412341234213412421341342342';
         $c = '0x1234123412341234123412341234123412412341234213412421341342342';
         $math = new BcEngine();
-        $this->assertEquals(gmp_strval(gmp_mul($a, $a)), $math->mul($a, $a));
-        $this->assertEquals(gmp_strval(gmp_mul($b, $b)), $math->mul($b, $b));
-        $this->assertEquals(gmp_strval(gmp_mul($c, $c)), $math->mul($c, $c));
+        $this->assertEquals(1522756, $math->mul($a, $a));
+        $this->assertEquals('1523060596888771785469376020510342038779135661438916853827453718463560582690945158853917400742616234688308574558442044964',
+            $math->mul($b, $b));
+        $this->assertEquals('4040760497619659988396017237570892345412667279675376001385393199805230792128304954488986267360185801341164900937850776470852477066413262703893764',
+            $math->mul($c, $c));
         $this->assertEquals(1, $math->mul(1, 1));
     }
 
@@ -123,10 +132,11 @@ class BcEngineTest extends \PHPUnit_Framework_TestCase
         $a = 1234;
         $b = '1234';
         $c = '0x4D2';
+        $pow = '20';
         $math = new BcEngine();
-        $this->assertEquals(gmp_strval(gmp_pow($a, $a)), $math->pow($a, $a));
-        $this->assertEquals(gmp_strval(gmp_pow($b, $b)), $math->pow($b, $b));
-        $this->assertEquals(gmp_strval(gmp_pow($c, $c)), $math->pow($c, $c));
+        $this->assertEquals('67035243914691711794360082394262505332216263021359359696306176', $math->pow($a, $pow));
+        $this->assertEquals('67035243914691711794360082394262505332216263021359359696306176', $math->pow($b, $pow));
+        $this->assertEquals('67035243914691711794360082394262505332216263021359359696306176', $math->pow($c, $pow));
         $this->assertEquals(1, $math->pow(1, 1));
     }
 
@@ -136,9 +146,11 @@ class BcEngineTest extends \PHPUnit_Framework_TestCase
         $b = '1234123412341234123412341234123412412341234213412421341342342';
         $c = '0x1234123412341234123412341234123412412341234213412421341342342';
         $math = new BcEngine();
-        $this->assertEquals(gmp_strval(gmp_sub($a, $a)), $math->sub($a, $a));
-        $this->assertEquals(gmp_strval(gmp_sub($b, $b)), $math->sub($b, $b));
-        $this->assertEquals(gmp_strval(gmp_sub($c, $c)), $math->sub($c, $c));
+        $this->assertEquals(0, $math->sub($a, $a));
+        $this->assertEquals('1234123412341234123412341234123412412341234213412421341341108',
+            $math->sub($b, $a));
+        $this->assertEquals('2010164296174493893887279757032336564542916106403683105277846450565757116',
+            $math->sub($c, $b));
         $this->assertEquals(0, $math->sub(1, 1));
     }
 


### PR DESCRIPTION
Remove gmp dependency when testing BcEngine.
It makes sense to isolate these tests, when gmp is not installed.