### PR TITLE
Fix some of the tests

### DIFF
--- a/src/Bitpay/Client/Response.php
+++ b/src/Bitpay/Client/Response.php
@@ -52,17 +52,19 @@ class Response implements ResponseInterface
     }
 
     /**
+     * @param string $rawResponse
+     * @return Response
      */
     public static function createFromRawResponse($rawResponse)
-   {
+    {
         $response = new self($rawResponse);
-        // remove HTTP 100 responses
-        $delimiter = "\r\n\r\n"; // HTTP header delimiter
-        // check if the 100 Continue header exists
-        while ( preg_match('#^HTTP/[0-9\\.]+\s+100\s+Continue#i',$rawResponse) ) {
-            $tmp = explode($delimiter,$rawResponse,2); // grab the 100 Continue header
-            $rawResponse = $tmp[1]; // update the response, purging the most recent 100 Continue header
-        } // repeat
+        //remove HTTP 100 responses
+        $delimiter = "\r\n\r\n";// HTTP header delimiter
+        //check if the 100 Continue header exists
+        while (preg_match('#^HTTP/[0-9\\.]+\s+100\s+Continue#i', $rawResponse)) {
+            $tmp = explode($delimiter, $rawResponse, 2);// grab the 100 Continue header
+            $rawResponse = $tmp[1];// update the response, purging the most recent 100 Continue header
+        }// repeat
         
         $lines    = preg_split('/(\\r?\\n)/', $rawResponse);
         $linesLen = count($lines);

--- a/src/Bitpay/Invoice.php
+++ b/src/Bitpay/Invoice.php
@@ -746,5 +746,4 @@ class Invoice implements InvoiceInterface
 
         return $this;
     }
-
 }

--- a/src/Bitpay/Invoice.php
+++ b/src/Bitpay/Invoice.php
@@ -30,7 +30,7 @@ class Invoice implements InvoiceInterface
     /**
      * @var string
      */
-    protected $transactionSpeed;
+    protected $transactionSpeed = self::TRANSACTION_SPEED_MEDIUM;
 
     /**
      * @var string
@@ -60,12 +60,12 @@ class Invoice implements InvoiceInterface
     /**
      * @var boolean
      */
-    protected $fullNotifications;
+    protected $fullNotifications = false;
 
     /**
      * @var boolean
      */
-    protected $extendedNotifications;
+    protected $extendedNotifications = false;
 
     /**
      * @var string
@@ -123,19 +123,9 @@ class Invoice implements InvoiceInterface
     protected $token;
 
     /**
-     * @var Array
+     * @var array
      */
     protected $refundAddresses;
-
-
-    /**
-     */
-    public function __construct()
-    {
-        $this->transactionSpeed  = self::TRANSACTION_SPEED_MEDIUM;
-        $this->fullNotifications = true;
-        $this->extendedNotifications = false;
-    }
 
     /**
      * @inheritdoc

--- a/src/Bitpay/Invoice.php
+++ b/src/Bitpay/Invoice.php
@@ -60,7 +60,7 @@ class Invoice implements InvoiceInterface
     /**
      * @var boolean
      */
-    protected $fullNotifications = false;
+    protected $fullNotifications = true;
 
     /**
      * @var boolean

--- a/src/Bitpay/User.php
+++ b/src/Bitpay/User.php
@@ -306,5 +306,4 @@ class User implements UserInterface
 
         return $this;
     }
-
 }

--- a/tests/Bitpay/Client/ClientTest.php
+++ b/tests/Bitpay/Client/ClientTest.php
@@ -622,9 +622,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                     'getExpirationTime', 'getCurrentTime', 'getOrderId', 'getItemDesc', 'getItemCode',
                     'isPhysical', 'getBuyerName', 'getBuyerAddress1', 'getBuyerAddress2', 'getBuyerCity',
                     'getBuyerState', 'getBuyerZip', 'getBuyerCountry', 'getBuyerEmail', 'getBuyerPhone',
-                    'getExceptionStatus', 'getBtcPaid', 'getRate', 'getToken', 'setId', 'setUrl',
-                    'setStatus', 'setBtcPrice', 'setPrice', 'setInvoiceTime', 'setExpirationTime',
-                    'setCurrentTime', 'setBtcPaid', 'setRate', 'setToken', 'setExceptionStatus',
+                    'getExceptionStatus', 'getBtcPaid', 'getRate', 'getToken', 'getRefundAddresses',
+                    'setId', 'setUrl', 'setStatus', 'setBtcPrice', 'setPrice', 'setInvoiceTime', 'setExpirationTime',
+                    'setCurrentTime', 'setBtcPaid', 'setRate', 'setToken', 'setExceptionStatus', 'isExtendedNotifications'
                 )
             )
             ->getMock();
@@ -688,6 +688,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                     'getState',
                     'getZip',
                     'getCountry',
+                    'getNotify'
                 )
             )
             ->getMock();

--- a/tests/Bitpay/InvoiceTest.php
+++ b/tests/Bitpay/InvoiceTest.php
@@ -181,7 +181,7 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
     public function testIsFullNotifications()
     {
         $this->assertNotNull($this->invoice);
-        $this->assertFalse($this->invoice->isFullNotifications());
+        $this->assertTrue($this->invoice->isFullNotifications());
     }
 
     public function testGetId()
@@ -523,9 +523,9 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
 
     public function testSetFullNotifications()
     {
-        $this->assertFalse($this->invoice->isFullNotifications());
-        $this->invoice->setFullNotifications(true);
         $this->assertTrue($this->invoice->isFullNotifications());
+        $this->invoice->setFullNotifications(false);
+        $this->assertFalse($this->invoice->isFullNotifications());
     }
 
     private function getMockItem()


### PR DESCRIPTION
Fixes some of the failing tests caused by missing mocked methods. (https://travis-ci.org/bitpay/php-bitpay-client/builds/231558997)

Example: 
> PHP Fatal error:  Class Mock_BuyerInterface_023dd71f contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Bitpay\UserInterface::getNotify) in /home/travis/build/bitpay/php-bitpay-client/vendor/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php(290)