### PR TITLE
Fixed token check in get invoices method for public facade calls

### DIFF
--- a/src/Bitpay/Client/Client.php
+++ b/src/Bitpay/Client/Client.php
@@ -559,7 +559,7 @@ class Client implements ClientInterface
     {
         $this->request = $this->createNewRequest();
         $this->request->setMethod(Request::METHOD_GET);
-        if ($this->token->getFacade() === 'merchant') {
+        if ($this->token && $this->token->getFacade() === 'merchant') {
             $this->request->setPath(sprintf('invoices/%s?token=%s', $invoiceId, $this->token->getToken()));
             $this->addIdentityHeader($this->request);
             $this->addSignatureHeader($this->request);


### PR DESCRIPTION
get invoice api could be called using Merchant and Public facade but the method does not handle correctly Public facade calls as it fails on token condition check if there is none.