### PR TITLE
Fix Codesniffer errors

### DIFF
--- a/src/Bitpay/Crypto/OpenSSLExtension.php
+++ b/src/Bitpay/Crypto/OpenSSLExtension.php
@@ -194,7 +194,8 @@ class OpenSSLExtension implements CryptoInterface
      * @throws Exception $e
      *
      */
-    public function encrypt($text, $key = '', $iv = '', $bit_check = 8, $cipher_type = 'AES-256-CBC') {
+    public function encrypt($text, $key = '', $iv = '', $bit_check = 8, $cipher_type = 'AES-256-CBC')
+    {
         try {
             if (function_exists('openssl_pkey_new')) {
                 /* Ensure the key & IV is the same for both encrypt & decrypt. */
@@ -236,7 +237,8 @@ class OpenSSLExtension implements CryptoInterface
      * @throws Exception $e
      *
      */
-    public function decrypt($encrypted_text, $key = '', $iv = '', $bit_check = 8, $cipher_type = 'AES-256-CBC') {
+    public function decrypt($encrypted_text, $key = '', $iv = '', $bit_check = 8, $cipher_type = 'AES-256-CBC')
+    {
         try {
             /* Ensure the key & IV is the same for both encrypt & decrypt. */
             if (!empty($encrypted_text)) {
@@ -258,5 +260,4 @@ class OpenSSLExtension implements CryptoInterface
             throw $e;
         }
     }
-
 }


### PR DESCRIPTION
Fixes these errors:
```
$ php bin/phpcs -n --standard=PSR1,PSR2 --report=full src/
FILE: ...s/build/bitpay/php-bitpay-client/src/Bitpay/Crypto/OpenSSLExtension.php
--------------------------------------------------------------------------------
FOUND 3 ERROR(S) AFFECTING 3 LINE(S)
--------------------------------------------------------------------------------
 197 | ERROR | Opening brace should be on a new line
 239 | ERROR | Opening brace should be on a new line
 262 | ERROR | The closing brace for the class must go on the next line after
     |       | the body
--------------------------------------------------------------------------------
```

Cheers