### PR TITLE
Consider removing ext-mcrypt as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-openssl": "*",
-        "ext-mcrypt": "*",
         "symfony/config": "^2.3 || ^3.0",
         "symfony/dependency-injection": "^2.3 || ^3.0"
     },
@@ -47,7 +46,8 @@
         "satooshi/php-coveralls": "~0.6.1"
     },
     "suggest": {
-        "ext-gmp": "Quickest PHP math extension for doing computationally-expensive work."
+        "ext-gmp": "Quickest PHP math extension for doing computationally-expensive work.",
+        "ext-mcrypt": "Interface to the mcrypt library"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
This library can also be used without ext-mcrypt. Also, ext-mcrypt has been deprecated as of PHP 7.1.0 and moved to PECL as of PHP 7.2.0 so it would be nice to make it optional unless really necessary. At the moment, the only reference to mcrypt_* functions are in McryptExtension file that is also optional?