### PR TITLE
Allow HTTP2 response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,9 @@
         "fabpot/goutte": "~1.0.4",
         "behat/mink-goutte-driver": "1.*",
         "phpmd/phpmd": "~2.1.3",
-        "phpunit/phpunit": "~4.8.35",
+        "phpunit/phpunit": "~5.7.9",
         "fzaninotto/faker": "~1.4.0",
-        "mikey179/vfsStream": "~1.4.0",
+        "mikey179/vfsstream": "~1.4.0",
         "squizlabs/php_codesniffer": "~1.5.5",
         "satooshi/php-coveralls": "~0.6.1",
         "symfony/phpunit-bridge": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpunit/phpunit": "~5.7.9",
         "fzaninotto/faker": "~1.4.0",
         "mikey179/vfsstream": "~1.4.0",
-        "squizlabs/php_codesniffer": "~1.5.5",
+        "squizlabs/php_codesniffer": "~3.4",
         "satooshi/php-coveralls": "~0.6.1",
         "symfony/phpunit-bridge": "^4.0"
     },

--- a/src/Bitpay/AccessTokenInterface.php
+++ b/src/Bitpay/AccessTokenInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2015 BitPay Inc., MIT License 
+ * @license Copyright 2011-2015 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Application.php
+++ b/src/Bitpay/Application.php
@@ -61,20 +61,4 @@ class Application implements ApplicationInterface
 
         return $this;
     }
-
-    /**
-     * Add org to stack
-     *
-     * @param OrgInterface $org
-     *
-     * @return ApplicationInterface
-     */
-    public function addOrg(OrgInterface $org)
-    {
-        if (!empty($org)) {
-            $this->orgs[] = $org;
-        }
-
-        return $this;
-    }
 }

--- a/src/Bitpay/Application.php
+++ b/src/Bitpay/Application.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2015 BitPay Inc., MIT License 
+ * @license Copyright 2011-2015 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/ApplicationInterface.php
+++ b/src/Bitpay/ApplicationInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Bill.php
+++ b/src/Bitpay/Bill.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/BillInterface.php
+++ b/src/Bitpay/BillInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Bitpay.php
+++ b/src/Bitpay/Bitpay.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Buyer.php
+++ b/src/Bitpay/Buyer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/BuyerInterface.php
+++ b/src/Bitpay/BuyerInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Client/Adapter/AdapterInterface.php
+++ b/src/Bitpay/Client/Adapter/AdapterInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Client/ArgumentException.php
+++ b/src/Bitpay/Client/ArgumentException.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Bitpay\Client;
 

--- a/src/Bitpay/Client/BitpayException.php
+++ b/src/Bitpay/Client/BitpayException.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Bitpay\Client;
 

--- a/src/Bitpay/Client/Client.php
+++ b/src/Bitpay/Client/Client.php
@@ -703,7 +703,7 @@ class Client implements ClientInterface
         if (($currency != 'BCH' && $currency != 'BTC') && $decimalPrecision > 2) {
             throw new \Bitpay\Client\BitpayException('Incorrect price format or currency type.');
         }
-        elseif ($decimalPrecision > 6) {
+        if ($decimalPrecision > 6) {
             throw new \Bitpay\Client\BitpayException('Incorrect price format or currency type.');
         }
     }

--- a/src/Bitpay/Client/ClientInterface.php
+++ b/src/Bitpay/Client/ClientInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Client/ConnectionException.php
+++ b/src/Bitpay/Client/ConnectionException.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Bitpay\Client;
 

--- a/src/Bitpay/Client/Request.php
+++ b/src/Bitpay/Client/Request.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 
@@ -52,7 +52,7 @@ class Request implements RequestInterface
     protected $path;
 
     /**
-     * Default is 443 but should be changed by whatever is passed in through the Adapter. 
+     * Default is 443 but should be changed by whatever is passed in through the Adapter.
      *
      * @var integer
      */

--- a/src/Bitpay/Client/RequestInterface.php
+++ b/src/Bitpay/Client/RequestInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Client/Response.php
+++ b/src/Bitpay/Client/Response.php
@@ -71,9 +71,9 @@ class Response implements ResponseInterface
 
         for ($i = 0; $i < $linesLen; $i++) {
             if (0 == $i) {
-                preg_match('/^HTTP\/(\d\.\d)\s(\d+)\s(.+)/', $lines[$i], $statusLine);
+                preg_match('#^HTTP/[0-9\\.]+\s(\d+)#', $lines[$i], $statusLine);
     
-                $response->setStatusCode($statusCode = $statusLine[2]);
+                $response->setStatusCode($statusCode = $statusLine[1]);
 
                 continue;
             }

--- a/src/Bitpay/Client/ResponseInterface.php
+++ b/src/Bitpay/Client/ResponseInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Crypto/CryptoInterface.php
+++ b/src/Bitpay/Crypto/CryptoInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Crypto/HashExtension.php
+++ b/src/Bitpay/Crypto/HashExtension.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Crypto/OpenSSLExtension.php
+++ b/src/Bitpay/Crypto/OpenSSLExtension.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 
@@ -242,7 +242,6 @@ class OpenSSLExtension implements CryptoInterface
         try {
             /* Ensure the key & IV is the same for both encrypt & decrypt. */
             if (!empty($encrypted_text)) {
-
                 $decrypted = openssl_decrypt(base64_decode($encrypted_text), $cipher_type, $key, 0, $iv);
                 $last_char = substr($decrypted, -1);
 

--- a/src/Bitpay/CurrencyInterface.php
+++ b/src/Bitpay/CurrencyInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/DependencyInjection/Loader/ArrayLoader.php
+++ b/src/Bitpay/DependencyInjection/Loader/ArrayLoader.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Invoice.php
+++ b/src/Bitpay/Invoice.php
@@ -779,7 +779,7 @@ class Invoice implements InvoiceInterface
     }
 
     /**
-     * @param 
+     * @param array
      * @return InvoiceInterface
      */
     public function setPaymentSubtotals($paymentSubtotals)
@@ -800,7 +800,7 @@ class Invoice implements InvoiceInterface
     }
 
     /**
-     * @param 
+     * @param array
      * @return InvoiceInterface
      */
     public function setPaymentTotals($paymentTotals)

--- a/src/Bitpay/InvoiceInterface.php
+++ b/src/Bitpay/InvoiceInterface.php
@@ -369,5 +369,4 @@ interface InvoiceInterface
     public function getAmountPaid();
 
     public function getExchangeRates();
-
 }

--- a/src/Bitpay/Item.php
+++ b/src/Bitpay/Item.php
@@ -161,11 +161,11 @@ class Item implements ItemInterface
      */
     protected function checkPriceFormat($price)
     {
-        if($price === '0')  {
+        if ($price === '0') {
             return;
         }
         $converted = (float)$price;
-        if($converted == 0) {
+        if ($converted == 0) {
             throw new \Bitpay\Client\ArgumentException("Price must be formatted as a float ". $converted);
         }
     }

--- a/src/Bitpay/ItemInterface.php
+++ b/src/Bitpay/ItemInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Key.php
+++ b/src/Bitpay/Key.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/KeyInterface.php
+++ b/src/Bitpay/KeyInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/KeyManager.php
+++ b/src/Bitpay/KeyManager.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Math/BcEngine.php
+++ b/src/Bitpay/Math/BcEngine.php
@@ -86,7 +86,6 @@ class BcEngine implements EngineInterface
             $x = $y;
 
             $y = $tmp;
-
         } while (bccomp($num1, '0'));
 
         if (bccomp($x, '0') < 0) {
@@ -168,13 +167,12 @@ class BcEngine implements EngineInterface
             }
 
             return $sign.$dec;
-
-        } elseif (preg_match('/^-?[0-9]+$/', $x)) {
+        }
+        if (preg_match('/^-?[0-9]+$/', $x)) {
             return $x;
-        } else {
-            throw new \Exception("The input must be a numeric string in decimal or hexadecimal (with leading 0x) format.\n".var_export($x, true));
         }
 
+        throw new \Exception("The input must be a numeric string in decimal or hexadecimal (with leading 0x) format.\n".var_export($x, true));
     }
 
     /**

--- a/src/Bitpay/Network/Customnet.php
+++ b/src/Bitpay/Network/Customnet.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Network/Livenet.php
+++ b/src/Bitpay/Network/Livenet.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Network/NetworkAware.php
+++ b/src/Bitpay/Network/NetworkAware.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Network/NetworkAwareInterface.php
+++ b/src/Bitpay/Network/NetworkAwareInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Network/NetworkInterface.php
+++ b/src/Bitpay/Network/NetworkInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Network/Testnet.php
+++ b/src/Bitpay/Network/Testnet.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Point.php
+++ b/src/Bitpay/Point.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/PointInterface.php
+++ b/src/Bitpay/PointInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/PublicKey.php
+++ b/src/Bitpay/PublicKey.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/SinKey.php
+++ b/src/Bitpay/SinKey.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Storage/EncryptedFilesystemStorage.php
+++ b/src/Bitpay/Storage/EncryptedFilesystemStorage.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Storage/FilesystemStorage.php
+++ b/src/Bitpay/Storage/FilesystemStorage.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Storage/MockStorage.php
+++ b/src/Bitpay/Storage/MockStorage.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Storage/StorageInterface.php
+++ b/src/Bitpay/Storage/StorageInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Token.php
+++ b/src/Bitpay/Token.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/TokenInterface.php
+++ b/src/Bitpay/TokenInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/User.php
+++ b/src/Bitpay/User.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/UserInterface.php
+++ b/src/Bitpay/UserInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Util/CurveParameterInterface.php
+++ b/src/Bitpay/Util/CurveParameterInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Util/Error.php
+++ b/src/Bitpay/Util/Error.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Util/Fingerprint.php
+++ b/src/Bitpay/Util/Fingerprint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Util/Secp256k1.php
+++ b/src/Bitpay/Util/Secp256k1.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Util/SecureRandom.php
+++ b/src/Bitpay/Util/SecureRandom.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License 
+ * @license Copyright 2011-2014 BitPay Inc., MIT License
  * see https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
  */
 

--- a/src/Bitpay/Util/Util.php
+++ b/src/Bitpay/Util/Util.php
@@ -296,7 +296,6 @@ class Util
             $yadd   = Math::add($ysub2, $ymul);
 
             $R['y'] = Math::mod($yadd, $p);
-
         } catch (\Exception $e) {
             throw new \Exception('Error in Util::pointDouble(): '.$e->getMessage());
         }

--- a/tests/Bitpay/ApplicationTest.php
+++ b/tests/Bitpay/ApplicationTest.php
@@ -52,19 +52,12 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotNull($application);
 
-        $application->addOrg($this->getMockOrg());
-
         $this->assertInternalType('array', $application->getOrgs());
-        $this->assertCount(1, $application->getOrgs());
+        $this->assertCount(0, $application->getOrgs());
     }
 
     private function getMockUser()
     {
-        return $this->getMock('Bitpay\UserInterface');
-    }
-
-    private function getMockOrg()
-    {
-        return $this->getMock('Bitpay\OrgInterface');
+        return $this->createMock('Bitpay\UserInterface');
     }
 }

--- a/tests/Bitpay/BillTest.php
+++ b/tests/Bitpay/BillTest.php
@@ -232,11 +232,11 @@ class BillTest extends \PHPUnit_Framework_TestCase
 
     private function getMockItem()
     {
-        return $this->getMock('Bitpay\ItemInterface');
+        return $this->createMock('Bitpay\ItemInterface');
     }
 
     private function getMockCurrency()
     {
-        return $this->getMock('Bitpay\CurrencyInterface');
+        return $this->createMock('Bitpay\CurrencyInterface');
     }
 }

--- a/tests/Bitpay/Client/ClientTest.php
+++ b/tests/Bitpay/Client/ClientTest.php
@@ -27,7 +27,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->client->setPublicKey($this->getMockPublicKey());
         $this->client->setPrivateKey($this->getMockPrivateKey());
         $adapter = $this->getMockAdapter();
-        $adapter->method('sendRequest')->willReturn($this->getMock('Bitpay\Client\ResponseInterface'));
+        $adapter->method('sendRequest')->willReturn($this->createMock('Bitpay\Client\ResponseInterface'));
         $this->client->setAdapter($adapter);
     }
 
@@ -204,7 +204,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testCreateResponseWithException()
     {
@@ -238,7 +238,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *  @expectedException Exception
+     *  @expectedException \Exception
      */
     public function testCreateInvoiceWithTooMuchPrecisionForAnythingButBitcoin()
     {
@@ -268,7 +268,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
 
     /**
-     *  @expectedException Exception
+     *  @expectedException \Exception
      */
     public function testCreateInvoiceWithTooMuchPrecisionEvenForBitcoin()
     {
@@ -315,7 +315,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     /**
      * @depends testGetRequest
      * @depends testGetResponse
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testCreateInvoiceWithError()
     {
@@ -346,7 +346,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testGetCurrenciesWithException()
     {
@@ -453,7 +453,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testCreateTokenWithException()
     {
@@ -496,7 +496,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testGetInvoiceException()
     {
@@ -528,7 +528,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testGetPayoutException()
     {
@@ -717,26 +717,26 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     private function getMockToken()
     {
-        return $this->getMock('Bitpay\TokenInterface');
+        return $this->createMock('Bitpay\TokenInterface');
     }
 
     private function getMockAdapter()
     {
-        return $this->getMock('Bitpay\Client\Adapter\AdapterInterface');
+        return $this->createMock('Bitpay\Client\Adapter\AdapterInterface');
     }
 
     private function getMockPublicKey()
     {
-        return $this->getMock('Bitpay\PublicKey');
+        return $this->createMock('Bitpay\PublicKey');
     }
 
     private function getMockPrivateKey()
     {
-        return $this->getMock('Bitpay\PrivateKey');
+        return $this->createMock('Bitpay\PrivateKey');
     }
 
     private function getMockResponse()
     {
-        return $this->getMock('Bitpay\Client\ResponseInterface');
+        return $this->createMock('Bitpay\Client\ResponseInterface');
     }
 }

--- a/tests/Bitpay/Client/ResponseTest.php
+++ b/tests/Bitpay/Client/ResponseTest.php
@@ -51,6 +51,9 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     {
         $response = Response::createFromRawResponse($this->getTestResponse200());
         $this->assertSame(200, $response->getStatusCode());
+
+        $response = Response::createFromRawResponse($this->getTestHttp2Response200());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -68,6 +71,18 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     {
         return <<<EOF
 HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+
+{
+  "response": "example"
+}
+EOF;
+    }
+
+    private function getTestHttp2Response200()
+    {
+        return <<<EOF
+HTTP/2 200
 Content-Type: text/xml; charset=utf-8
 
 {

--- a/tests/Bitpay/Math/GmpEngineTest.php
+++ b/tests/Bitpay/Math/GmpEngineTest.php
@@ -107,8 +107,8 @@ class GmpEngineTest extends \PHPUnit_Framework_TestCase
         $c = '0x1234123412341234123412341234123412412341234213412421341342342';
         $math = new GmpEngine();
         $this->assertEquals(gmp_strval(gmp_pow($a, $a)), $math->pow($a, $a));
-        $this->assertEquals(gmp_strval(gmp_pow($b, $b)), $math->pow($b, $b));
-        $this->assertEquals(gmp_strval(gmp_pow($c, $c)), $math->pow($c, $c));
+        $this->assertEquals(gmp_strval(gmp_pow($b, $a)), $math->pow($b, $a));
+        $this->assertEquals(gmp_strval(gmp_pow($c, $a)), $math->pow($c, $a));
         $this->assertEquals(1, $math->pow(1, 1));
     }
 

--- a/tests/Bitpay/Math/MathTest.php
+++ b/tests/Bitpay/Math/MathTest.php
@@ -17,7 +17,7 @@ class MathTest extends \PHPUnit_Framework_TestCase
 	{
 		Math::setEngine(null);
 		$this->assertNull(Math::getEngine());
-		$engine = $this->getMock('Bitpay\Math\EngineInterface');
+		$engine = $this->createMock('Bitpay\Math\EngineInterface');
 		Math::setEngine($engine);
 		$this->assertInstanceOf('Bitpay\Math\EngineInterface', Math::getEngine());
 	}

--- a/tests/Bitpay/PublicKeyTest.php
+++ b/tests/Bitpay/PublicKeyTest.php
@@ -236,7 +236,7 @@ class PublicKeyTest extends \PHPUnit_Framework_TestCase
     private function getMockPrivateKey($hex = null)
     {
         $hex = ($hex === null) ? $this->hexKeys[0]['private'] : $hex;
-        $key = $this->getMock('Bitpay\PrivateKey');
+        $key = $this->createMock('Bitpay\PrivateKey');
         $key->method('isValid')->will($this->returnValue(true));
 
         $key


### PR DESCRIPTION
What seemed like a tiny change resulted in updating phpunit and codesniffer and fixes of the codebase accordingly.
Anyway the point is HTTP2 response can be resolved by the client now.